### PR TITLE
Add Azure AD auth, update configs, and enhance tests

### DIFF
--- a/Api/src/UrlShortener.Api/Program.cs
+++ b/Api/src/UrlShortener.Api/Program.cs
@@ -1,4 +1,9 @@
+using System.Security.Authentication;
+using System.Security.Claims;
 using Azure.Identity;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Identity.Web;
 using UrlShortener.Api;
 using UrlShortener.Api.Extensions;
 using UrlShortener.Core.Urls.Add;
@@ -34,6 +39,37 @@ builder.Services.AddHttpClient("TokenRangeService",
 builder.Services.AddSingleton<ITokenRangeApiClient, TokenRangeApiClient>();
 builder.Services.AddHostedService<TokenManager>();
 
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddMicrosoftIdentityWebApi(options =>
+        {
+            builder.Configuration.Bind("AzureAd", options);
+            options.TokenValidationParameters.NameClaimType = "name";
+        },
+        options =>
+        {
+            builder.Configuration.Bind("AzureAd", options);
+
+        });
+
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy("AuthZPolicy", policyBuilder =>
+        policyBuilder.Requirements.Add(new ScopeAuthorizationRequirement()
+        {
+            RequiredScopesConfigurationKey = "AzureAd:Scopes"
+        }));
+
+builder.Services.AddAuthorization(options =>
+{
+    options.DefaultPolicy = 
+        new AuthorizationPolicyBuilder(
+                JwtBearerDefaults.AuthenticationScheme)
+        .RequireAuthenticatedUser()
+        .Build();
+    // By default, all incoming requests will be authorized according to 
+    // the default policy    
+    options.FallbackPolicy = options.DefaultPolicy;
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -44,15 +80,25 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
-app.MapGet("/", () => "API");
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapGet("/", () => "API")
+    .AllowAnonymous();
+
 app.MapPost("/api/urls",
     async (AddUrlHandler handler,
         AddUrlRequest request,
+        HttpContext context,
         CancellationToken cancellationToken) =>
     {
+        var email = context.User.FindFirstValue("preferred_username")
+                    ?? throw new AuthenticationException("Missing preferred_username claim");
+            
         var requestWithUser = request with
         {
-            CreatedBy = "gui@guiferreira.me"
+            CreatedBy = email
         };
         var result = await handler.HandleAsync(requestWithUser, cancellationToken);
 

--- a/Api/src/UrlShortener.Api/UrlShortener.Api.csproj
+++ b/Api/src/UrlShortener.Api/UrlShortener.Api.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
   </ItemGroup>

--- a/Api/src/UrlShortener.Api/appsettings.Development.json
+++ b/Api/src/UrlShortener.Api/appsettings.Development.json
@@ -4,5 +4,19 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "DatabaseName": "urls",
+  "ContainerName": "items",
+  "TokenRangeService": {
+    "Endpoint": "https://token-range-service-kjlcpthy3q5jk.azurewebsites.net/"
+  },
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "ClientId": "3e32bf84-e6de-4e07-bb88-9d5904f89dbe",
+    "TenantId": "edd05a20-4105-4c0c-b959-9b80aa2a1f7f",
+    "Scopes": "Urls.Read"
+  },
+  "CosmosDb": {
+    "ConnectionString": ""
   }
 }

--- a/Api/tests/UrlShortener.Tests/AddUrlFeature.cs
+++ b/Api/tests/UrlShortener.Tests/AddUrlFeature.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using UrlShortener.Core.Urls.Add;
 
@@ -11,6 +12,8 @@ public class AddUrlFeature : IClassFixture<ApiFixture>
     public AddUrlFeature(ApiFixture fixture)
     {
         _client = fixture.CreateClient();
+        _client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(scheme: "TestScheme");
     }
 
     [Fact]

--- a/Api/tests/UrlShortener.Tests/ApiFixture.cs
+++ b/Api/tests/UrlShortener.Tests/ApiFixture.cs
@@ -1,7 +1,13 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using UrlShortener.Api;
 using UrlShortener.Core.Urls.Add;
 using UrlShortener.Tests.Extensions;
@@ -23,9 +29,48 @@ public class ApiFixture : WebApplicationFactory<IApiAssemblyMarker>
                 
                 services.Remove<ITokenRangeApiClient>();
                 services.AddSingleton<ITokenRangeApiClient, FakeTokenRangeApiClient>();
+                
+                services.AddAuthentication(defaultScheme: "TestScheme")
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        "TestScheme", options => { });
+                
+                services.AddAuthorization(options =>
+                {
+                    options.DefaultPolicy = new AuthorizationPolicyBuilder()
+                        .RequireAuthenticatedUser()
+                        .Build();
+                    options.FallbackPolicy = null;
+                });
+
             }
         );
         
         base.ConfigureWebHost(builder);
+    }
+}
+
+public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger, UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, "Test user"),
+            new Claim("preferred_username", "gui@guiferreira.me"),
+        };
+        var identity = new ClaimsIdentity(claims, "Test");
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, 
+            "TestScheme");
+
+        var result = AuthenticateResult.Success(ticket);
+
+        return Task.FromResult(result);
     }
 }


### PR DESCRIPTION
Introduce authentication and authorization using Azure AD and JWT Bearer tokens in `Program.cs`. Update `appsettings.Development.json` with Azure AD, Cosmos DB, and token range service settings. Add `Microsoft.Identity.Web` package to `UrlShortener.Api.csproj`. Modify `AddUrlFeature.cs` to set default auth header for HTTP client in tests. Update `ApiFixture.cs` to configure test auth scheme and handler. Add `TestAuthHandler` class for simulating authentication. Update `AddUrlHandler` in `Program.cs` to use user's email from auth context.